### PR TITLE
Added a 'more-strict' banMode that deny passwords that contains one of the bannedPasswords (case insensitive)

### DIFF
--- a/jquery.complexify.js
+++ b/jquery.complexify.js
@@ -138,9 +138,16 @@
 			function inBanlist(str) {
 				if (options.banMode === 'strict') {
 					for (var i = 0; i < options.bannedPasswords.length; i++) {
-            if (options.bannedPasswords[i].indexOf(str) !== -1) {
-              return true;
-            }
+            					if (options.bannedPasswords[i].indexOf(str) !== -1) {
+              						return true;
+            					}
+					}
+					return false;
+				} else if (options.banMode === 'more-strict') {
+					for (var i = 0; i < options.bannedPasswords.length; i++) {
+            					if (str.toLowerCase().indexOf(options.bannedPasswords[i].toLowerCase()) !== -1) {
+              						return true;
+            					}
 					}
 					return false;
 				} else {


### PR DESCRIPTION
Added a 'more-strict' banMode that deny passwords that contains one of the bannedPasswords (case insensitive)

I think this mode is more meaningful and secure (and annoying to the user).
Maybe changing the name 'more-strict' to a more creative name.