### PR TITLE
Update the bower install

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For more information, a demo, documentation, and the motivation behind Complexif
 
 You can install this by using npm or bower
 
-    bower install jquery.complexify
+    bower install jquery.complexify.js --save
     npm install jquery.complexify@0.5.2
 
 ### Contributing


### PR DESCRIPTION
Bower has this package registered under jquery.complexify.js and not jquery.complexify.

```
# bower install jquery.complexify --save
bower                        ENOTFOUND Package jquery.complexify not found
```

```
# bower install jquery.complexify.js --save
bower jquery.complexify.js#*       not-cached https://github.com/danpalmer/jquery.complexify.js.git#*
bower jquery.complexify.js#*          resolve https://github.com/danpalmer/jquery.complexify.js.git#*
bower jquery.complexify.js#*         checkout 0.5.1
bower jquery.complexify.js#*         resolved https://github.com/danpalmer/jquery.complexify.js.git#0.5.1
bower jquery.complexify#^0.5.1        install jquery.complexify#0.5.1
```
